### PR TITLE
Setting: batteryinfo: Add config to enable/disable battery design & m…

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -45,6 +45,12 @@
     <!-- Show battery cycle count -->
     <bool name="config_show_battery_cycle_count" translatable="false">false</bool>
 
+    <!-- Show battery Design Capacity -->
+    <bool name="config_show_battery_design_capacity">true</bool>
+
+    <!-- Show battery Maximum Capacity -->
+    <bool name="config_show_battery_maximum_capacity">true</bool>
+
     <!-- Default min refresh rate -->
     <integer name="default_min_refresh_rate" translatable="false">60</integer>
 </resources>

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
@@ -35,7 +35,8 @@ public class BatteryDesignCapacityPreferenceController extends BasePreferenceCon
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        boolean isFeatureEnabled = mContext.getResources().getBoolean(R.bool.config_show_battery_design_capacity);
+        return isFeatureEnabled ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
@@ -35,7 +35,8 @@ public class BatteryMaximumCapacityPreferenceController extends BasePreferenceCo
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        boolean isFeatureEnabled = mContext.getResources().getBoolean(R.bool.config_show_battery_maximum_capacity);
+        return isFeatureEnabled ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override


### PR DESCRIPTION
…aximum capacity info

* Legacy devices like the Pixel 2 Series do not support this feature, only show Unavailable for design capacity and maximum capacity in battery information.
* Enabled by default

Test: Build & flash