### PR TITLE
Revert "DerpFestSettings: hide navbar tuner if gesture nav enabled"

### DIFF
--- a/src/com/android/settings/derpfest/buttons/ButtonSettings.java
+++ b/src/com/android/settings/derpfest/buttons/ButtonSettings.java
@@ -9,7 +9,6 @@ package com.android.settings.derpfest.buttons;
 import static android.inputmethodservice.InputMethodService.canImeRenderGesturalNavButtons;
 import static android.view.WindowManagerPolicyConstants.NAV_BAR_MODE_2BUTTON;
 import static android.view.WindowManagerPolicyConstants.NAV_BAR_MODE_3BUTTON;
-import static android.view.WindowManagerPolicyConstants.NAV_BAR_MODE_GESTURAL;
 import static android.view.WindowManagerPolicyConstants.NAV_BAR_MODE_3BUTTON_OVERLAY;
 import static android.view.WindowManagerPolicyConstants.NAV_BAR_MODE_GESTURAL_OVERLAY;
 
@@ -106,7 +105,6 @@ public class ButtonSettings extends SettingsPreferenceFragment
     private static final String KEY_SWAP_CAPACITIVE_KEYS = "swap_capacitive_keys";
     private static final String KEY_NAV_BAR_INVERSE = "sysui_nav_bar_inverse";
     private static final String KEY_ENABLE_TASKBAR = "enable_taskbar";
-    private static final String KEY_NAVBAR_TUNER = "navbar_tuner";
 
     private static final String CATEGORY_POWER = "power_key";
     private static final String CATEGORY_HOME = "home_key";
@@ -146,7 +144,6 @@ public class ButtonSettings extends SettingsPreferenceFragment
     private SwitchPreferenceCompat mSwapCapacitiveKeys;
     private SwitchPreferenceCompat mNavBarInverse;
     private SwitchPreferenceCompat mEnableTaskbar;
-    private Preference mNavbarTuner;
 
     private PreferenceCategory mNavigationPreferencesCat;
 
@@ -479,11 +476,6 @@ public class ButtonSettings extends SettingsPreferenceFragment
             }
         }
 
-        mNavbarTuner = findPreference(KEY_NAVBAR_TUNER);
-        if (canImeRenderGesturalNavButtons() && isGestureNavigationEnabled(getActivity())) {
-            extrasCategory.removePreference(mNavbarTuner);
-        }
-
         List<Integer> unsupportedValues = new ArrayList<>();
         List<String> entries = new ArrayList<>(
                 Arrays.asList(res.getStringArray(R.array.hardware_keys_action_entries)));
@@ -689,11 +681,6 @@ public class ButtonSettings extends SettingsPreferenceFragment
 
     private static boolean is3ButtonNavigationEnabled(Context context) {
         return NAV_BAR_MODE_3BUTTON == context.getResources().getInteger(
-                com.android.internal.R.integer.config_navBarInteractionMode);
-    }
-
-    private static boolean isGestureNavigationEnabled(Context context) {
-        return NAV_BAR_MODE_GESTURAL == context.getResources().getInteger(
                 com.android.internal.R.integer.config_navBarInteractionMode);
     }
 


### PR DESCRIPTION
This reverts commit e107fd4f37b289879f0f7230684aec12e9dec0f5.

and fixes java.lang.NullPointerException: Attempt to invoke virtual method 'void androidx.preference.Preference.onPrepareForRemoval()' on a null object reference


after the removal of navbar tuner in vendor/derp, we need to revert this as well to avoid Settings/System/Buttons crashing due to it still referencing navbar tuner stuff.